### PR TITLE
Replace exit events with close

### DIFF
--- a/platforms/darwin.js
+++ b/platforms/darwin.js
@@ -75,7 +75,7 @@ KeychainAccess.prototype.getPassword = function(opts, fn) {
     password += d.toString();
   });
 
-  security.on('exit', function(code, signal) {
+  security.on('close', function(code, signal) {
     if (code !== 0) {
       err = new Error('Could not find password');
       fn(err, null);

--- a/platforms/darwin.js
+++ b/platforms/darwin.js
@@ -125,7 +125,7 @@ KeychainAccess.prototype.setPassword = function(opts, fn) {
   var security = spawn(this.executablePath, [ 'add-generic-password', '-a', opts.account, '-s', opts.service, '-w', opts.password ]);
   var self = this;
 
-  security.on('exit', function(code, signal) {
+  security.on('close', function(code, signal) {
     if (code !== 0) {
       var msg = 'Security returned a non-successful error code: ' + code;
 
@@ -177,7 +177,7 @@ KeychainAccess.prototype.deletePassword = function(opts, fn) {
 
   var security = spawn(this.executablePath, [ 'delete-generic-password', '-a', opts.account, '-s', opts.service ]);
 
-  security.on('exit', function(code, signal) {
+  security.on('close', function(code, signal) {
     if (code !== 0) {
       err = new Error('Could not find password');
       fn(err);

--- a/platforms/linux.js
+++ b/platforms/linux.js
@@ -75,7 +75,7 @@ KeychainAccess.prototype.getPassword = function(opts, fn) {
    password += d.toString();
   });
 
-  security.on('exit', function(code, signal) {
+  security.on('close', function(code, signal) {
 	// console.log('password='+password+'');
     if (code !== 0) {
       err = new Error('Could not find password');


### PR DESCRIPTION
Given the documentation for the [exit](https://nodejs.org/api/child_process.html#child_process_event_exit) event, it seems that the password may yet be outputted on `stderr` even after the `exit` event has been sent.

Therefore, replacing the exit event with [close](https://nodejs.org/api/child_process.html#child_process_event_close) will ensure that any data that would be sent to `stderr` is sent before the end.

In short, while using the `getPassword` function from this module I was receiving errors where the stderr `data` event was fired after the `exit` event on the child process, resulting in an error even though the password was indeed sent.
